### PR TITLE
Update `GitHubBranchRegex`

### DIFF
--- a/Runner/Helpers/RuntimeHelpers.cs
+++ b/Runner/Helpers/RuntimeHelpers.cs
@@ -152,6 +152,17 @@ internal static class RuntimeHelpers
         await job.RunProcessAsync("cp", $"-r {BaseDirectory}/{folder}/. {destination}", logPrefix: logPrefix);
     }
 
+    public static async Task CopyReleaseTestAssembliesAsync(JobBase job, string branch, string destination)
+    {
+        AssertIsLinux();
+
+        string logPrefix = $"{branch} release";
+
+        string arch = JobBase.IsArm ? "arm64" : "x64";
+
+        await job.RunProcessAsync("cp", $"-r runtime/artifacts/tests/libraries/linux.{arch}.Release/. {destination}", logPrefix: logPrefix);
+    }
+
     public static int GetDotnetVersion()
     {
         // "version": "10.0.100-preview.1.12345.6", => 10

--- a/Runner/Helpers/RuntimeHelpers.cs
+++ b/Runner/Helpers/RuntimeHelpers.cs
@@ -170,9 +170,10 @@ internal static class RuntimeHelpers
                     .Where(dir => Path.GetFileName(dir).StartsWith("net", StringComparison.OrdinalIgnoreCase))
                     .Single();
 
-                string dllPath = Path.Combine(folder, $"{name}.dll");
-
-                File.Copy(dllPath, Path.Combine(destination, $"{name}.dll"));
+                foreach (string dll in Directory.GetFiles(folder, "*.dll"))
+                {
+                    File.Copy(dll, Path.Combine(destination, Path.GetFileName(dll)));
+                }
             }
         });
     }

--- a/Runner/Helpers/RuntimeHelpers.cs
+++ b/Runner/Helpers/RuntimeHelpers.cs
@@ -160,7 +160,7 @@ internal static class RuntimeHelpers
 
         string logPrefix = $"{branch} release";
 
-        Parallel.ForEach(Directory.GetDirectories("runtime/artifacts/tests/libraries"), dir =>
+        Parallel.ForEach(Directory.GetDirectories("runtime/artifacts/bin"), dir =>
         {
             string name = Path.GetFileName(dir);
 

--- a/Runner/Jobs/BenchmarkLibrariesJob.cs
+++ b/Runner/Jobs/BenchmarkLibrariesJob.cs
@@ -245,7 +245,7 @@ internal sealed partial class BenchmarkLibrariesJob : JobBase
     // https://github.com/MihaZupan/performance/tree/regex
     // https://github.com/MihaZupan/performance/blob/regex/.gitignore#L5
     // we want 'MihaZupan/performance' and optionally 'regex'
-    [GeneratedRegex(@"https://github\.com/([A-Za-z0-9-]+/[A-Za-z0-9-_\.]+)(?:/(?:tree|blob)/(?!/)([A-Za-z0-9-_\.]+)(?<!\.)(?:[\?#/].*)?)?", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    [GeneratedRegex(@"https://github\.com/([A-Za-z0-9-]+/[A-Za-z0-9-_\.]+)(?:/(?:tree|blob)/([A-Za-z0-9-_\.]+)(?<!\.)(?:[\?#/].*)?)?", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex GitHubBranchRegex();
 
     // | Count  | Main | (?i)Sher[a-z]+|Hol[a-z]+ |

--- a/Runner/Jobs/BenchmarkLibrariesJob.cs
+++ b/Runner/Jobs/BenchmarkLibrariesJob.cs
@@ -245,7 +245,7 @@ internal sealed partial class BenchmarkLibrariesJob : JobBase
     // https://github.com/MihaZupan/performance/tree/regex
     // https://github.com/MihaZupan/performance/blob/regex/.gitignore#L5
     // we want 'MihaZupan/performance' and optionally 'regex'
-    [GeneratedRegex(@"https://github\.com/([A-Za-z\d-_\.]+/[A-Za-z\d-_\.]+)(?:/(?:tree|blob)/([A-Za-z\d-_\.]+)(?:[\?#/].*)?)?", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    [GeneratedRegex(@"https://github\.com/([A-Za-z0-9-]+/[A-Za-z0-9-_\.]+)(?:/(?:tree|blob)/(?!/)([A-Za-z0-9-_\.]+)(?<!\.)(?:[\?#/].*)?)?", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex GitHubBranchRegex();
 
     // | Count  | Main | (?i)Sher[a-z]+|Hol[a-z]+ |


### PR DESCRIPTION
* Usernames for user accounts on GitHub can only contain alphanumeric characters and dashes ( - ).
* Allow only ASCII for decimal digits
* Branch name cannot begin with a forward slash or end with a period